### PR TITLE
Fix typo in descendents_of function and add a test

### DIFF
--- a/src/descendents.rs
+++ b/src/descendents.rs
@@ -5,10 +5,13 @@ use libc::pid_t;
 use std::collections::HashMap;
 
 pub fn descendents_of(parent_pid: pid_t) -> Result<Vec<pid_t>, String> {
+    let parents_to_children = map_parents_to_children()?;
+    get_descendents(parent_pid, parents_to_children)
+}
+
+pub fn get_descendents(parent_pid: pid_t, parents_to_children: HashMap<pid_t, Vec<pid_t>>) -> Result<Vec<pid_t>, String> {
     let mut result = Vec::<pid_t>::new();
     let mut queue = Vec::<pid_t>::new();
-
-    let parents_to_children = map_parents_to_children()?;
     queue.push(parent_pid);
 
     loop {
@@ -25,11 +28,31 @@ pub fn descendents_of(parent_pid: pid_t) -> Result<Vec<pid_t>, String> {
 					},
 					None => ()
 				}
-				result.push(parent_pid);
+				result.push(current_pid);
             }
         }
     }
 }
+
+
+#[test]
+fn test_get_descendents() {
+    let mut map = HashMap::new();
+    map.insert(1, vec!(2));
+    let desc = get_descendents(1, map).unwrap();
+    assert_eq!(desc, vec!(1,2));
+}
+
+#[test]
+fn test_get_descendents_depth_2() {
+    let mut map = HashMap::new();
+    map.insert(1, vec!(2,3));
+    map.insert(2, vec!(4));
+    let desc = get_descendents(1, map).unwrap();
+    assert_eq!(desc, vec!(1,3,2,4));
+}
+
+
 
 fn map_parents_to_children() -> Result<HashMap<pid_t, Vec<pid_t>>, String> {
     let mut pid_map: HashMap<pid_t, Vec<pid_t>> = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -683,12 +683,8 @@ mod tests {
             Args {
                 cmd: Record {
                     target: Pid { pid: 1234 },
-                    out_path: "foo.txt".into(),
                     sample_rate: 100,
-                    maybe_duration: None,
-                    format: OutputFormat::Callgrind,
                     maybe_filename: Some("foo.txt".to_string()),
-                    sample_rate: 100,
                     maybe_duration: None,
                     format: OutputFormat::Flamegraph,
                     no_drop_root: false,


### PR DESCRIPTION
There was a typo in the `descendents_of` function that meant that it reported the descendents of process `n` as `[n,n,n,n]` (because it was pushing `parent_pid` instead of `current_pid`). This adds a test and fixes the typo.

It also fixes a few typos in `main` which were preventing the tests from compiling.