### PR TITLE
Use channels when recording in parallel

### DIFF
--- a/src/descendents.rs
+++ b/src/descendents.rs
@@ -5,10 +5,13 @@ use libc::pid_t;
 use std::collections::HashMap;
 
 pub fn descendents_of(parent_pid: pid_t) -> Result<Vec<pid_t>, String> {
+    let parents_to_children = map_parents_to_children()?;
+    get_descendents(parent_pid, parents_to_children)
+}
+
+pub fn get_descendents(parent_pid: pid_t, parents_to_children: HashMap<pid_t, Vec<pid_t>>) -> Result<Vec<pid_t>, String> {
     let mut result = Vec::<pid_t>::new();
     let mut queue = Vec::<pid_t>::new();
-
-    let parents_to_children = map_parents_to_children()?;
     queue.push(parent_pid);
 
     loop {
@@ -25,11 +28,31 @@ pub fn descendents_of(parent_pid: pid_t) -> Result<Vec<pid_t>, String> {
 					},
 					None => ()
 				}
-				result.push(parent_pid);
+				result.push(current_pid);
             }
         }
     }
 }
+
+
+#[test]
+fn test_get_descendents() {
+    let mut map = HashMap::new();
+    map.insert(1, vec!(2));
+    let desc = get_descendents(1, map).unwrap();
+    assert_eq!(desc, vec!(1,2));
+}
+
+#[test]
+fn test_get_descendents_depth_2() {
+    let mut map = HashMap::new();
+    map.insert(1, vec!(2,3));
+    map.insert(2, vec!(4));
+    let desc = get_descendents(1, map).unwrap();
+    assert_eq!(desc, vec!(1,3,2,4));
+}
+
+
 
 fn map_parents_to_children() -> Result<HashMap<pid_t, Vec<pid_t>>, String> {
     let mut pid_map: HashMap<pid_t, Vec<pid_t>> = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -683,12 +683,8 @@ mod tests {
             Args {
                 cmd: Record {
                     target: Pid { pid: 1234 },
-                    out_path: "foo.txt".into(),
                     sample_rate: 100,
-                    maybe_duration: None,
-                    format: OutputFormat::Callgrind,
                     maybe_filename: Some("foo.txt".to_string()),
-                    sample_rate: 100,
                     maybe_duration: None,
                     format: OutputFormat::Flamegraph,
                     no_drop_root: false,

--- a/src/output.rs
+++ b/src/output.rs
@@ -8,12 +8,12 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use callgrind;
-use initialize::StackFrame;
+use initialize::StackTrace;
 
 const FLAMEGRAPH_SCRIPT: &'static [u8] = include_bytes!("../vendor/flamegraph/flamegraph.pl");
 
 pub trait Outputter {
-    fn record(&mut self, file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error>;
+    fn record(&mut self, file: &mut File, stack: &StackTrace) -> Result<(), Error>;
     fn complete(&mut self, path: &Path, file: File) -> Result<(), Error>;
 }
 
@@ -22,8 +22,8 @@ pub trait Outputter {
 pub struct Flamegraph;
 
 impl Outputter for Flamegraph {
-    fn record(&mut self, file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
-        for t in stack.iter().rev() {
+    fn record(&mut self, file: &mut File, stack: &StackTrace) -> Result<(), Error> {
+        for t in stack.trace.iter().rev() {
             write!(file, "{}", t)?;
             write!(file, ";")?;
         }
@@ -41,8 +41,8 @@ impl Outputter for Flamegraph {
 pub struct Callgrind(pub callgrind::Stats);
 
 impl Outputter for Callgrind {
-    fn record(&mut self, _file: &mut File, stack: &Vec<StackFrame>) -> Result<(), Error> {
-        self.0.add(stack);
+    fn record(&mut self, file: &mut File, stack: &StackTrace) -> Result<(), Error> {
+        self.0.add(&stack.trace);
         Ok(())
     }
 

--- a/src/ruby_version.rs
+++ b/src/ruby_version.rs
@@ -117,12 +117,13 @@ macro_rules! ruby_version_v2_5_x(
 macro_rules! get_stack_trace(
     ($thread_type:ident) => (
 
-        use initialize::StackFrame;
+        use initialize::{StackFrame, Process, StackTrace};
 
         pub fn get_stack_trace<T>(
             ruby_current_thread_address_location: usize,
-            source: &T,
-            ) -> Result<Vec<StackFrame>, MemoryCopyError> where T: CopyAddress{
+            process: &Process<T>,
+            ) -> Result<StackTrace, MemoryCopyError> where T: CopyAddress {
+            let source = &process.source;
             let current_thread_addr: usize =
                 copy_struct(ruby_current_thread_address_location, source)?;
             let thread: $thread_type = copy_struct(current_thread_addr, source)?;
@@ -151,7 +152,7 @@ macro_rules! get_stack_trace(
                     }
                 }
             }
-            Ok(trace)
+            Ok(StackTrace{trace, pid: process.pid})
         }
 
 use proc_maps::{maps_contain_addr, MapRange};
@@ -539,7 +540,7 @@ mod tests {
 
     use ruby_version;
 
-    use initialize::StackFrame;
+    use initialize::{StackFrame, Process};
 
     fn real_stack_trace_main() -> Vec<StackFrame> {
         vec![
@@ -609,35 +610,35 @@ mod tests {
     fn test_get_ruby_stack_trace_2_1_6() {
         let current_thread_addr = 0x562658abd7f0;
         let stack_trace =
-            ruby_version::ruby_2_1_6::get_stack_trace(current_thread_addr, &*COREDUMP_2_1_6)
+            ruby_version::ruby_2_1_6::get_stack_trace::<CoreDump>(current_thread_addr, &Process{pid: 0, source: COREDUMP_2_1_6.into()})
             .unwrap();
-        assert_eq!(real_stack_trace_main(), stack_trace);
+        assert_eq!(real_stack_trace_main(), stack_trace.trace);
     }
 
     #[test]
     fn test_get_ruby_stack_trace_1_9_3() {
         let current_thread_addr = 0x823930;
         let stack_trace =
-            ruby_version::ruby_1_9_3_0::get_stack_trace(current_thread_addr, &*COREDUMP_1_9_3)
+            ruby_version::ruby_1_9_3_0::get_stack_trace::<CoreDump>(current_thread_addr, &Process{pid: 0, source: COREDUMP_1_9_3.into()})
             .unwrap();
-        assert_eq!(real_stack_trace_main(), stack_trace);
+        assert_eq!(real_stack_trace_main(), stack_trace.trace);
     }
 
     #[test]
     fn test_get_ruby_stack_trace_2_5_0() {
         let current_thread_addr = 0x55dd8c3b7758;
         let stack_trace =
-            ruby_version::ruby_2_5_0_rc1::get_stack_trace(current_thread_addr, &*COREDUMP_2_5_0)
+            ruby_version::ruby_2_5_0_rc1::get_stack_trace::<CoreDump>(current_thread_addr, &Process{pid: 0, source: COREDUMP_2_5_0.into()})
             .unwrap();
-        assert_eq!(real_stack_trace(), stack_trace);
+        assert_eq!(real_stack_trace(), stack_trace.trace);
     }
 
     #[test]
     fn test_get_ruby_stack_trace_2_4_0() {
         let current_thread_addr = 0x55df44959920;
         let stack_trace =
-            ruby_version::ruby_2_4_0::get_stack_trace(current_thread_addr, &*COREDUMP_2_4_0)
+            ruby_version::ruby_2_4_0::get_stack_trace::<COREDUMP_2_4_0>(current_thread_addr, &Process{pid: 0, source: *COREDUMP_2_4_0.into()})
             .unwrap();
-        assert_eq!(real_stack_trace(), stack_trace);
+        assert_eq!(real_stack_trace(), stack_trace.trace);
     }
 }


### PR DESCRIPTION
This adds to your recording subprocesses feature! This PR:

a) creates a new `StackTrace` struct for holding stack traces and adds a PID field to that struct.
b) instead of recording to 1 file per thread, changes the design so that instead every thread writes the stack traces it's recording to a channel. All the aggregation happens in the main thread.

This way, we can save all the records for a session to the same file, and we instead want to record to a different file for each PID, that's also possible to implement relatively easily -- we'd just need to write an aggregator that creates 1 file per PID.

Interested to hear what you think -- one big reason I'm excited about this approach is that it'll be dramatically easier to merge with https://github.com/rbspy/rbspy/pull/106, which introduces a "raw data" file format. (we could just record the PID and trace for every stack trace).